### PR TITLE
Function for Appending multiple controls at once

### DIFF
--- a/box.go
+++ b/box.go
@@ -92,12 +92,28 @@ func (b *Box) Disable() {
 
 // Append adds the given control to the end of the Box.
 func (b *Box) Append(child Control, stretchy bool) {
+	b.AppendMultipleEx(stretchy, child)
+}
+
+// Append multiple (non-stretchy) controls to the end of the Box.
+func (b *Box) AppendMultiple(children ...Control) {
+	b.AppendMultipleEx(false, children...)
+}
+
+// AppendMultiple but allows "stretchy" parameter
+func (b *Box) AppendMultipleEx(stretchy bool, children ...Control) {
 	c := (*C.uiControl)(nil)
-	if child != nil {
+
+	for _, child := range children {
+		if nil == child {
+			continue
+		}
+
 		c = touiControl(child.LibuiControl())
+
+		C.uiBoxAppend(b.b, c, frombool(stretchy))
+		b.children = append(b.children, child)
 	}
-	C.uiBoxAppend(b.b, c, frombool(stretchy))
-	b.children = append(b.children, child)
 }
 
 // Delete deletes the nth control of the Box.


### PR DESCRIPTION
Append() adds one control at a time, while it is a common
use-case that a user wants to add several controls. This
leads to the unnecessary repetion of a single function call.

AppendMultiple() appends controls as non-stretchy, while
AppendMultipleEx() allows boolean to explicitely specify
the type of control.

Standard Append() was changed to use AppendMultipleEx() too.